### PR TITLE
Fix missing full_name and license_classifiers in cookiecutter initiation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "full_name": "yaq Developers",
   "project_name": "yaqd-boilerplate",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
   "project_src_dir": "{{ cookiecutter.project_slug.lower().replace(' ', '_').replace('-', '_') }}",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -17,9 +17,6 @@ dynamic = ["version"]
 "Apache Software License 2.0": "Apache-2.0",
 "GNU General Public License v3 (GPL)": "GPL-3.0-only"
 } %}
-{%- if cookiecutter.open_source_license in license_classifiers %}
-license="{{ license_spdx[cookiecutter.open_source_license] }}"
-{%- endif %}
 {%- set license_classifiers = {
 "GNU Lesser General Public License v3 (LGPL)": "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 "MIT license": "License :: OSI Approved :: MIT License",
@@ -28,6 +25,9 @@ license="{{ license_spdx[cookiecutter.open_source_license] }}"
 "Apache Software License 2.0": "License :: OSI Approved :: Apache Software License",
 "GNU General Public License v3 (GPL)": "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 } %}
+{%- if cookiecutter.open_source_license in license_classifiers %}
+license="{{ license_spdx[cookiecutter.open_source_license] }}"
+{%- endif %}
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "{{ cookiecutter.project_slug }}"
-authors = [{name="yaq developers"}]
+authors = ["{{ cookiecutter.full_name.replace('\"', '\\\"') }}"]
 readme = "README.md"
 requires-python = ">=3.7"
 requires = ["yaqd-core>=2020.06.3"]


### PR DESCRIPTION
This pull request fixes these issues:
- `full_name` is not asked during cookiecutter initiation, but it is required in `{{cookiecutter.project_slug}}/LICENSE`
- `license_classifiers` is used before creation in `{{cookiecutter.project_slug}}/pyproject.toml`
- `authors` field in `{{cookiecutter.project_slug}}/pyproject.toml` does not respect user input from cookiecutter initiation