### PR TITLE
Simplify `license` field in `pyproject.toml`

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -9,14 +9,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 requires = ["yaqd-core>=2020.06.3"]
 dynamic = ["version"]
-{%- set license_spdx = {
-"GNU Lesser General Public License v3 (LGPL)": "LGPL-3.0-only",
-"MIT license": "MIT",
-"BSD license": "BSD-3-Clause",
-"ISC license": "ISC",
-"Apache Software License 2.0": "Apache-2.0",
-"GNU General Public License v3 (GPL)": "GPL-3.0-only"
-} %}
+license = {file = "LICENSE"}
 {%- set license_classifiers = {
 "GNU Lesser General Public License v3 (LGPL)": "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 "MIT license": "License :: OSI Approved :: MIT License",
@@ -25,9 +18,6 @@ dynamic = ["version"]
 "Apache Software License 2.0": "License :: OSI Approved :: Apache Software License",
 "GNU General Public License v3 (GPL)": "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 } %}
-{%- if cookiecutter.open_source_license in license_classifiers %}
-license="{{ license_spdx[cookiecutter.open_source_license] }}"
-{%- endif %}
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
This PR change `license` field to a link to the `LICENSE` file in `pyproject.toml` and removes all unused code.