### PR TITLE
Use updated syntaxis for project dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -7,7 +7,9 @@ name = "{{ cookiecutter.project_slug }}"
 authors = ["{{ cookiecutter.full_name.replace('\"', '\\\"') }}"]
 readme = "README.md"
 requires-python = ">=3.7"
-requires = ["yaqd-core>=2020.06.3"]
+dependencies = [
+  "yaqd-core>=2020.06.3",
+]
 dynamic = ["version"]
 {%- set license_spdx = {
 "GNU Lesser General Public License v3 (LGPL)": "LGPL-3.0-only",


### PR DESCRIPTION
This PR changes the way package dependencies are declared in `pyproject.toml` file according to [flit format](https://flit.pypa.io/en/stable/pyproject_toml.html#pyproject-project-dependencies).