### PR TITLE
Fix missing `version` for `hatch`

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -74,3 +74,6 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.hatch.version]
+path = "{{ cookiecutter.project_src_dir }}/__version__.py"


### PR DESCRIPTION
This PR adds `tool.hatch.version` field as a link to `__version__.py`